### PR TITLE
Add Supabase image dashboard and slider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,40 +1,19 @@
-<<<<<<< HEAD
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# faya-one-link
 
-## Getting Started
+This project is a small Next.js application. A simple dashboard page allows uploading images to a Supabase storage bucket and a slideshow on the landing page displays those images.
 
-First, run the development server:
+## Setup
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+Create a `.env.local` file and provide your Supabase credentials:
+
+```
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Install dependencies and run the development server:
 
-You can start editing the page by modifying `app/page.js`. The page auto-updates as you edit the file.
-
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
-
-## Learn More
-
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
-=======
-# faya-one-link
->>>>>>> 3671b4f6628e41799405809772b936047a24b880
+```
+npm install
+npm run dev
+```

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-slick": "^0.30.3",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "@supabase/supabase-js": "^2.39.8"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/dashboard/page.jsx
+++ b/src/app/dashboard/page.jsx
@@ -1,0 +1,56 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function Dashboard() {
+  const [images, setImages] = useState([]);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    fetchImages();
+  }, []);
+
+  async function fetchImages() {
+    const { data, error } = await supabase.storage
+      .from('images')
+      .list('', { limit: 100, offset: 0, sortBy: { column: 'name', order: 'desc' } });
+    if (error) {
+      console.error('Error loading images', error);
+    } else {
+      const urls = data.map((file) =>
+        supabase.storage.from('images').getPublicUrl(file.name).data.publicUrl,
+      );
+      setImages(urls);
+    }
+  }
+
+  async function handleUpload(e) {
+    const file = e.target.files[0];
+    if (!file) return;
+    setUploading(true);
+    const { error } = await supabase.storage
+      .from('images')
+      .upload(`${Date.now()}_${file.name}`, file);
+    setUploading(false);
+    if (error) {
+      alert('حدث خطأ أثناء الرفع');
+    } else {
+      fetchImages();
+    }
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-2xl font-bold mb-4">لوحة التحكم</h1>
+      <input type="file" onChange={handleUpload} disabled={uploading} className="mb-6" />
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {images.map((url, idx) => (
+          <div key={idx} className="relative w-full h-48 rounded overflow-hidden">
+            <Image src={url} alt={`img-${idx}`} fill className="object-cover" unoptimized />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/page.jsx
+++ b/src/app/page.jsx
@@ -4,9 +4,9 @@
 import React from "react";
 import Head from "next/head";
 import Image from "next/image";
-import Slider from "react-slick";
 import "slick-carousel/slick/slick.css";
 import "slick-carousel/slick/slick-theme.css";
+import SupabaseSlider from "@/components/SupabaseSlider";
 import { motion } from "framer-motion";
 import {
   FaShoppingCart,
@@ -58,28 +58,6 @@ const gradients = [
   "from-slate-200/40 to-slate-300/40"
 ];
 
-// —————————— إعدادات السلايدر ——————————
-const sliderSettings = {
-  dots: true,                   // تفعيل عداد النقاط :contentReference[oaicite:0]{index=0}
-  infinite: true,               // للتكرار اللانهائي
-  speed: 800,                   // سرعة التحريك (مللي ثواني)
-  slidesToShow: 1,              // شريحة واحدة ظاهرة
-  slidesToScroll: 1,            // التمرير شريحة واحدة في كل مرة
-  autoplay: true,               // تفعيل التشغيل التلقائي :contentReference[oaicite:1]{index=1}
-  autoplaySpeed: 3000,          // المدة بين كل انتقال (3 ثواني)
-  pauseOnHover: true,           // إيقاف مؤقت عند المرور بالفأرة
-  appendDots: dots => (
-    <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
-      <ul className="flex space-x-2 pointer-events-auto">{dots}</ul>
-    </div>
-  ),                             // وضع النقاط في منتصف السلايدر :contentReference[oaicite:2]{index=2}
-  customPaging: i => (
-    <button
-      className="w-3 h-3 rounded-full bg-white/50 hover:bg-white transition-all duration-200"
-      aria-label={`شريحة ${i + 1}`}
-    />
-  )                              // تصميم مخصص لكل نقطة
-};
 export default function LandingPage() {
   return (
     <>
@@ -149,25 +127,7 @@ export default function LandingPage() {
 
             {/* Slider */}
             <div className="mb-16">
-              <Slider {...sliderSettings}>
-                {products.map((prod) => (
-                  <div key={prod.id} className="px-2">
-                    <div className="relative h-64 sm:h-80 md:h-96 rounded-3xl group relative flex flex-col overflow-hidden rounded-3xl bg-white/70 backdrop-blur border border-slate-200 transition-all">
-                      <Image
-                        src={"/images/faya-erp.png"}
-                        alt={prod.title}
-                        fill
-                        unoptimized
-                        className="object-cover"
-                        sizes="(min-width: 768px) 70vw, 90vw"
-                      />
-                      <div className="absolute inset-0 flex items-end p-4">
-                        <h3 className="text-white text-xl font-semibold">{prod.title}</h3>
-                      </div>
-                    </div>
-                  </div>
-                ))}
-              </Slider>
+              <SupabaseSlider />
             </div>
 
             {/* Grid */}

--- a/src/components/SupabaseSlider.jsx
+++ b/src/components/SupabaseSlider.jsx
@@ -1,0 +1,67 @@
+'use client';
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Slider from 'react-slick';
+import { supabase } from '@/lib/supabaseClient';
+
+const sliderSettings = {
+  dots: true,
+  infinite: true,
+  speed: 800,
+  slidesToShow: 1,
+  slidesToScroll: 1,
+  autoplay: true,
+  autoplaySpeed: 3000,
+  pauseOnHover: true,
+  appendDots: (dots) => (
+    <div className="absolute inset-0 flex items-center justify-center z-10 pointer-events-none">
+      <ul className="flex space-x-2 pointer-events-auto">{dots}</ul>
+    </div>
+  ),
+  customPaging: (i) => (
+    <button
+      className="w-3 h-3 rounded-full bg-white/50 hover:bg-white transition-all duration-200"
+      aria-label={`شريحة ${i + 1}`}
+    />
+  ),
+};
+
+export default function SupabaseSlider() {
+  const [images, setImages] = useState([]);
+
+  useEffect(() => {
+    const fetchImages = async () => {
+      const { data, error } = await supabase.storage
+        .from('images')
+        .list('', { limit: 100, offset: 0, sortBy: { column: 'name', order: 'desc' } });
+      if (error) {
+        console.error('Error fetching images', error);
+        return;
+      }
+      const urls = data.map((file) =>
+        supabase.storage.from('images').getPublicUrl(file.name).data.publicUrl,
+      );
+      setImages(urls);
+    };
+    fetchImages();
+  }, []);
+
+  return (
+    <Slider {...sliderSettings}>
+      {images.map((url, idx) => (
+        <div key={idx} className="px-2">
+          <div className="relative h-64 sm:h-80 md:h-96 rounded-3xl overflow-hidden bg-white/70 backdrop-blur border border-slate-200">
+            <Image
+              src={url}
+              alt={`slide-${idx}`}
+              fill
+              unoptimized
+              className="object-cover"
+              sizes="(min-width: 768px) 70vw, 90vw"
+            />
+          </div>
+        </div>
+      ))}
+    </Slider>
+  );
+}

--- a/src/lib/supabaseClient.js
+++ b/src/lib/supabaseClient.js
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+export const supabase = createClient(supabaseUrl, supabaseKey);


### PR DESCRIPTION
## Summary
- integrate Supabase client
- add slider component that fetches images from Supabase
- add dashboard page to upload images
- wire slider into landing page
- document Supabase setup in README
- add Supabase package dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d36c8c248321aea7b7dd1ef00e2b